### PR TITLE
FEAT: Add scopes

### DIFF
--- a/query_select_criteria.go
+++ b/query_select_criteria.go
@@ -205,6 +205,9 @@ func SelectOrderAsc(column string) SelectCriteria {
 // - values: It should be a slice i.e. of IDs
 func SelectColumnIn[T any](column string, slice []T) SelectCriteria {
 	return func(q *bun.SelectQuery) *bun.SelectQuery {
+		if len(slice) == 0 {
+			return q
+		}
 		// fmt.Sprintf("?TableAlias.%s
 		return q.Where(fmt.Sprintf("?TableAlias.%s IN (?)", column), bun.In(slice))
 	}
@@ -214,6 +217,9 @@ func SelectColumnIn[T any](column string, slice []T) SelectCriteria {
 // - values: It should be a slice i.e. of IDs
 func SelectColumnNotIn[T any](column string, slice []T) SelectCriteria {
 	return func(q *bun.SelectQuery) *bun.SelectQuery {
+		if len(slice) == 0 {
+			return q
+		}
 		return q.Where(fmt.Sprintf("?TableAlias.%s NOT IN (?)", column), bun.In(slice))
 	}
 }
@@ -234,8 +240,12 @@ func SelectColumnInSubq(column string, query string, args ...any) SelectCriteria
 //				WHERE email is NOT NULL
 //	  )
 func SelectColumnNotInSubq(column string, query string, args ...any) SelectCriteria {
+	trimmed := strings.TrimSpace(query)
 	return func(q *bun.SelectQuery) *bun.SelectQuery {
-		return q.Where(fmt.Sprintf("?TableAlias.%s NOT IN (?)", column), bun.SafeQuery(query, args...))
+		if trimmed == "" {
+			return q
+		}
+		return q.Where(fmt.Sprintf("?TableAlias.%s NOT IN (?)", column), bun.SafeQuery(trimmed, args...))
 	}
 }
 

--- a/query_select_criteria_test.go
+++ b/query_select_criteria_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,4 +25,28 @@ func TestSelectSubquery_CustomAlias(t *testing.T) {
 
 	sql := query.String()
 	assert.Contains(t, sql, `AS "custom_alias"`)
+}
+
+func TestSelectColumnIn_EmptySliceNoOp(t *testing.T) {
+	setupTestData(t)
+
+	query := db.NewSelect().
+		Model((*TestUser)(nil)).
+		Apply(SelectColumnIn("id", []uuid.UUID{}))
+
+	sql := query.String()
+	assert.NotContains(t, sql, "IN ()")
+	assert.NotContains(t, sql, "IN (NULL)")
+}
+
+func TestSelectColumnNotIn_EmptySliceNoOp(t *testing.T) {
+	setupTestData(t)
+
+	query := db.NewSelect().
+		Model((*TestUser)(nil)).
+		Apply(SelectColumnNotIn("id", []uuid.UUID{}))
+
+	sql := query.String()
+	assert.NotContains(t, sql, "NOT IN ()")
+	assert.NotContains(t, sql, "NOT IN (NULL)")
 }

--- a/query_update_criteria.go
+++ b/query_update_criteria.go
@@ -98,3 +98,10 @@ func UpdateSetColumn(col string, val any) UpdateCriteria {
 		return q.SetColumn(col, "?", val)
 	}
 }
+
+// UpdateSkipZeroValues opt-in helper to omit zero-valued columns.
+func UpdateSkipZeroValues() UpdateCriteria {
+	return func(q *bun.UpdateQuery) *bun.UpdateQuery {
+		return q.OmitZero()
+	}
+}

--- a/repo.go
+++ b/repo.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 	"sync"
@@ -23,6 +24,26 @@ type DeleteCriteria func(*bun.DeleteQuery) *bun.DeleteQuery
 
 // InsertCriteria is the function we use to create insert queries
 type InsertCriteria func(*bun.InsertQuery) *bun.InsertQuery
+
+type ScopeSelectFunc func(context.Context) []SelectCriteria
+type ScopeUpdateFunc func(context.Context) []UpdateCriteria
+type ScopeInsertFunc func(context.Context) []InsertCriteria
+type ScopeDeleteFunc func(context.Context) []DeleteCriteria
+
+type ScopeDefinition struct {
+	Select ScopeSelectFunc
+	Update ScopeUpdateFunc
+	Insert ScopeInsertFunc
+	Delete ScopeDeleteFunc
+}
+
+type ScopeDefaults struct {
+	All    []string
+	Select []string
+	Update []string
+	Insert []string
+	Delete []string
+}
 
 type Repository[T any] interface {
 	Raw(ctx context.Context, sql string, args ...any) ([]T, error)
@@ -69,6 +90,9 @@ type Repository[T any] interface {
 	ForceDeleteTx(ctx context.Context, tx bun.IDB, record T) error
 
 	Handlers() ModelHandlers[T]
+	RegisterScope(name string, scope ScopeDefinition)
+	SetScopeDefaults(defaults ScopeDefaults)
+	GetScopeDefaults() ScopeDefaults
 }
 
 type Meta[T any] interface {
@@ -81,6 +105,17 @@ type repo[T any] struct {
 	fields   map[reflect.Type][]ModelField
 	driver   string
 	fieldsMu sync.Mutex
+	scopes   map[string]ScopeDefinition
+	scopesMu sync.RWMutex
+
+	scopeDefaults ScopeDefaults
+}
+
+func (r *repo[T]) resetScopes() {
+	r.scopesMu.Lock()
+	defer r.scopesMu.Unlock()
+	r.scopes = nil
+	r.scopeDefaults = ScopeDefaults{}
 }
 
 type ModelHandlers[T any] struct {
@@ -179,6 +214,33 @@ func (r *repo[T]) Handlers() ModelHandlers[T] {
 	return r.handlers
 }
 
+func (r *repo[T]) RegisterScope(name string, scope ScopeDefinition) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+
+	r.scopesMu.Lock()
+	if r.scopes == nil {
+		r.scopes = make(map[string]ScopeDefinition)
+	}
+	r.scopes[name] = scope
+	r.scopesMu.Unlock()
+}
+
+func (r *repo[T]) SetScopeDefaults(defaults ScopeDefaults) {
+	r.scopesMu.Lock()
+	r.scopeDefaults = CloneScopeDefaults(defaults)
+	r.scopesMu.Unlock()
+}
+
+func (r *repo[T]) GetScopeDefaults() ScopeDefaults {
+	r.scopesMu.RLock()
+	defer r.scopesMu.RUnlock()
+
+	return CloneScopeDefaults(r.scopeDefaults)
+}
+
 func (r *repo[T]) Get(ctx context.Context, criteria ...SelectCriteria) (T, error) {
 	return r.GetTx(ctx, r.db, criteria...)
 }
@@ -186,6 +248,8 @@ func (r *repo[T]) Get(ctx context.Context, criteria ...SelectCriteria) (T, error
 func (r *repo[T]) GetTx(ctx context.Context, tx bun.IDB, criteria ...SelectCriteria) (T, error) {
 	record := r.handlers.NewRecord()
 	q := tx.NewSelect().Model(record)
+
+	q = r.applySelectScopes(ctx, q)
 
 	for _, c := range criteria {
 		q.Apply(c)
@@ -221,6 +285,8 @@ func (r *repo[T]) ListTx(ctx context.Context, tx bun.IDB, criteria ...SelectCrit
 	// if we apply again in criteria, we override
 	q.Limit(25).Offset(0)
 
+	q = r.applySelectScopes(ctx, q)
+
 	for _, c := range criteria {
 		q.Apply(c)
 	}
@@ -244,6 +310,8 @@ func (r *repo[T]) CountTx(ctx context.Context, tx bun.IDB, criteria ...SelectCri
 
 	q := tx.NewSelect().
 		Model(record)
+
+	q = r.applySelectScopes(ctx, q)
 
 	for _, c := range criteria {
 		q.Apply(c)
@@ -270,6 +338,8 @@ func (r *repo[T]) CreateTx(ctx context.Context, tx bun.IDB, record T, criteria .
 		r.handlers.SetID(record, newID)
 	}
 	q := tx.NewInsert().Model(record)
+
+	q = r.applyInsertScopes(ctx, q)
 
 	for _, c := range criteria {
 		q.Apply(c)
@@ -302,6 +372,8 @@ func (r *repo[T]) CreateManyTx(ctx context.Context, tx bun.IDB, records []T, cri
 	}
 
 	q := tx.NewInsert().Model(&records)
+
+	q = r.applyInsertScopes(ctx, q)
 
 	for _, c := range criteria {
 		q.Apply(c)
@@ -359,7 +431,23 @@ func (r *repo[T]) GetOrCreateTx(ctx context.Context, tx bun.IDB, record T) (T, e
 		return existing, nil
 	}
 
-	return r.CreateTx(ctx, tx, record)
+	created, err := r.CreateTx(ctx, tx, record)
+	if err != nil {
+		if IsDuplicatedKey(err) {
+			existing, found, lookupErr := r.findExistingRecord(ctx, tx, record)
+			if lookupErr != nil {
+				var zero T
+				return zero, lookupErr
+			}
+			if found {
+				return existing, nil
+			}
+		}
+		var zero T
+		return zero, err
+	}
+
+	return created, nil
 }
 
 func (r *repo[T]) GetByIdentifier(ctx context.Context, identifier string, criteria ...SelectCriteria) (T, error) {
@@ -375,6 +463,8 @@ func (r *repo[T]) GetByIdentifierTx(ctx context.Context, tx bun.IDB, identifier 
 	}
 	record := r.handlers.NewRecord()
 	q := tx.NewSelect().Model(record)
+
+	q = r.applySelectScopes(ctx, q)
 
 	for _, c := range criteria {
 		q.Apply(c)
@@ -394,12 +484,15 @@ func (r *repo[T]) Update(ctx context.Context, record T, criteria ...UpdateCriter
 
 func (r *repo[T]) UpdateTx(ctx context.Context, tx bun.IDB, record T, criteria ...UpdateCriteria) (T, error) {
 	q := tx.NewUpdate().Model(record)
+
+	q = r.applyUpdateScopes(ctx, q)
+
 	for _, c := range criteria {
 		q.Apply(c)
 	}
 	// TODO: WherePK will auto generate "ws"."id" = '44a3e9dc-0381-37a6-9652-99ea14057af5'
 	// so we can call it with model having the ID and we don't need criteria
-	res, err := q.OmitZero().WherePK().Returning("*").Exec(ctx)
+	res, err := q.WherePK().Returning("*").Exec(ctx)
 
 	if err != nil {
 		var zero T
@@ -424,12 +517,14 @@ func (r *repo[T]) UpdateManyTx(ctx context.Context, tx bun.IDB, records []T, cri
 	}
 
 	q := tx.NewUpdate().Model(&records).Bulk()
+
+	q = r.applyUpdateScopes(ctx, q)
+
 	for _, c := range criteria {
 		q.Apply(c)
 	}
 
 	_, err := q.
-		OmitZero().
 		WherePK().
 		Returning("*").
 		Exec(ctx)
@@ -533,6 +628,9 @@ func (r *repo[T]) Delete(ctx context.Context, record T) error {
 
 func (r *repo[T]) DeleteTx(ctx context.Context, tx bun.IDB, record T) error {
 	q := tx.NewDelete().Model(record).WherePK()
+
+	q = r.applyDeleteScopes(ctx, q)
+
 	_, err := q.Exec(ctx)
 	return r.mapError(err)
 }
@@ -552,6 +650,9 @@ func (r *repo[T]) DeleteWhere(ctx context.Context, criteria ...DeleteCriteria) e
 func (r *repo[T]) DeleteWhereTx(ctx context.Context, tx bun.IDB, criteria ...DeleteCriteria) error {
 	record := r.handlers.NewRecord()
 	q := tx.NewDelete().Model(record)
+
+	q = r.applyDeleteScopes(ctx, q)
+
 	for _, c := range criteria {
 		q.Apply(c)
 	}
@@ -565,6 +666,9 @@ func (r *repo[T]) ForceDelete(ctx context.Context, record T) error {
 
 func (r *repo[T]) ForceDeleteTx(ctx context.Context, tx bun.IDB, record T) error {
 	q := tx.NewDelete().Model(record).WherePK().ForceDelete()
+
+	q = r.applyDeleteScopes(ctx, q)
+
 	_, err := q.Exec(ctx)
 	return r.mapError(err)
 }
@@ -572,6 +676,105 @@ func (r *repo[T]) ForceDeleteTx(ctx context.Context, tx bun.IDB, record T) error
 func (r *repo[T]) TableName() string {
 	var model T
 	return r.db.NewCreateTable().Model(model).GetTableName()
+}
+
+func (r *repo[T]) applySelectScopes(ctx context.Context, q *bun.SelectQuery) *bun.SelectQuery {
+	for _, scope := range r.resolveSelectScopes(ctx) {
+		q = scope(q)
+	}
+	return q
+}
+
+func (r *repo[T]) applyUpdateScopes(ctx context.Context, q *bun.UpdateQuery) *bun.UpdateQuery {
+	for _, scope := range r.resolveUpdateScopes(ctx) {
+		q = scope(q)
+	}
+	return q
+}
+
+func (r *repo[T]) applyInsertScopes(ctx context.Context, q *bun.InsertQuery) *bun.InsertQuery {
+	for _, scope := range r.resolveInsertScopes(ctx) {
+		q = scope(q)
+	}
+	return q
+}
+
+func (r *repo[T]) applyDeleteScopes(ctx context.Context, q *bun.DeleteQuery) *bun.DeleteQuery {
+	for _, scope := range r.resolveDeleteScopes(ctx) {
+		q = scope(q)
+	}
+	return q
+}
+
+func (r *repo[T]) resolveSelectScopes(ctx context.Context) []SelectCriteria {
+	defs := r.resolveScopeDefinitions(ctx, ScopeOperationSelect)
+	var result []SelectCriteria
+	for _, def := range defs {
+		if def.Select == nil {
+			continue
+		}
+		result = append(result, def.Select(ctx)...)
+	}
+	return result
+}
+
+func (r *repo[T]) resolveUpdateScopes(ctx context.Context) []UpdateCriteria {
+	defs := r.resolveScopeDefinitions(ctx, ScopeOperationUpdate)
+	var result []UpdateCriteria
+	for _, def := range defs {
+		if def.Update == nil {
+			continue
+		}
+		result = append(result, def.Update(ctx)...)
+	}
+	return result
+}
+
+func (r *repo[T]) resolveInsertScopes(ctx context.Context) []InsertCriteria {
+	defs := r.resolveScopeDefinitions(ctx, ScopeOperationInsert)
+	var result []InsertCriteria
+	for _, def := range defs {
+		if def.Insert == nil {
+			continue
+		}
+		result = append(result, def.Insert(ctx)...)
+	}
+	return result
+}
+
+func (r *repo[T]) resolveDeleteScopes(ctx context.Context) []DeleteCriteria {
+	defs := r.resolveScopeDefinitions(ctx, ScopeOperationDelete)
+	var result []DeleteCriteria
+	for _, def := range defs {
+		if def.Delete == nil {
+			continue
+		}
+		result = append(result, def.Delete(ctx)...)
+	}
+	return result
+}
+
+func (r *repo[T]) resolveScopeDefinitions(ctx context.Context, op ScopeOperation) []ScopeDefinition {
+	r.scopesMu.RLock()
+	defaults := CloneScopeDefaults(r.scopeDefaults)
+	defsMap := make(map[string]ScopeDefinition, len(r.scopes))
+	maps.Copy(defsMap, r.scopes)
+	r.scopesMu.RUnlock()
+
+	state := ResolveScopeState(ctx, defaults, op)
+
+	defs := make([]ScopeDefinition, 0, len(state.Names))
+	for _, raw := range state.Names {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		if def, ok := defsMap[name]; ok {
+			defs = append(defs, def)
+		}
+	}
+
+	return defs
 }
 
 func DetectDriver(db *bun.DB) string {

--- a/repo_test.go
+++ b/repo_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -246,6 +247,184 @@ func TestRepository_GetByIdentifier_NotFound(t *testing.T) {
 	assert.True(t, IsRecordNotFound(err))
 }
 
+func TestRepository_Scopes_SelectDefault(t *testing.T) {
+	setupTestData(t)
+
+	ctx := context.Background()
+	companyRepo := newTestCompanyRepository(db)
+	userRepo := newTestUserRepository(db)
+	userRepo.(*repo[*TestUser]).resetScopes()
+
+	const tenantScope = "tenant"
+
+	userRepo.RegisterScope(tenantScope, ScopeDefinition{
+		Select: func(ctx context.Context) []SelectCriteria {
+			val, ok := ScopeData(ctx, tenantScope)
+			if !ok {
+				return nil
+			}
+			tenantID, ok := val.(uuid.UUID)
+			if !ok || tenantID == uuid.Nil {
+				return nil
+			}
+			return []SelectCriteria{
+				SelectBy("company_id", "=", tenantID.String()),
+			}
+		},
+	})
+	userRepo.SetScopeDefaults(ScopeDefaults{
+		Select: []string{tenantScope},
+	})
+
+	tenantCompany := &TestCompany{
+		ID:         uuid.New(),
+		Name:       "Tenant Co",
+		Identifier: "tenant-co",
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+	_, err := companyRepo.CreateTx(ctx, db, tenantCompany)
+	assert.NoError(t, err)
+
+	otherCompany := &TestCompany{
+		ID:         uuid.New(),
+		Name:       "Other Co",
+		Identifier: "other-co",
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+	_, err = companyRepo.CreateTx(ctx, db, otherCompany)
+	assert.NoError(t, err)
+
+	users := []*TestUser{
+		{
+			ID:        uuid.New(),
+			Name:      "Tenant User",
+			Email:     "tenant@example.com",
+			CompanyID: tenantCompany.ID,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+		{
+			ID:        uuid.New(),
+			Name:      "Other User",
+			Email:     "other@example.com",
+			CompanyID: otherCompany.ID,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+	}
+
+	for _, user := range users {
+		_, err := userRepo.CreateTx(ctx, db, user)
+		assert.NoError(t, err)
+	}
+
+	scopedCtx := WithScopeData(ctx, tenantScope, tenantCompany.ID)
+
+	records, total, err := userRepo.List(scopedCtx)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, total)
+	if assert.Len(t, records, 1) {
+		assert.Equal(t, tenantCompany.ID, records[0].CompanyID)
+		assert.Equal(t, "Tenant User", records[0].Name)
+	}
+}
+
+func TestRepository_Scopes_UpdateRestriction(t *testing.T) {
+	setupTestData(t)
+
+	ctx := context.Background()
+	companyRepo := newTestCompanyRepository(db)
+	userRepo := newTestUserRepository(db)
+	userRepo.(*repo[*TestUser]).resetScopes()
+
+	const tenantScope = "tenant"
+
+	userRepo.RegisterScope(tenantScope, ScopeDefinition{
+		Select: func(ctx context.Context) []SelectCriteria {
+			val, ok := ScopeData(ctx, tenantScope)
+			if !ok {
+				return nil
+			}
+			tenantID, ok := val.(uuid.UUID)
+			if !ok || tenantID == uuid.Nil {
+				return nil
+			}
+			return []SelectCriteria{
+				SelectBy("company_id", "=", tenantID.String()),
+			}
+		},
+		Update: func(ctx context.Context) []UpdateCriteria {
+			val, ok := ScopeData(ctx, tenantScope)
+			if !ok {
+				return nil
+			}
+			tenantID, ok := val.(uuid.UUID)
+			if !ok || tenantID == uuid.Nil {
+				return nil
+			}
+			return []UpdateCriteria{
+				UpdateBy("company_id", "=", tenantID.String()),
+			}
+		},
+	})
+
+	tenantCompany := &TestCompany{
+		ID:         uuid.New(),
+		Name:       "Tenant Co",
+		Identifier: "tenant-co",
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+	_, err := companyRepo.CreateTx(ctx, db, tenantCompany)
+	assert.NoError(t, err)
+
+	otherCompany := &TestCompany{
+		ID:         uuid.New(),
+		Name:       "Other Co",
+		Identifier: "other-co",
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+	_, err = companyRepo.CreateTx(ctx, db, otherCompany)
+	assert.NoError(t, err)
+
+	user := &TestUser{
+		ID:        uuid.New(),
+		Name:      "Tenant User",
+		Email:     "tenant@example.com",
+		CompanyID: tenantCompany.ID,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	created, err := userRepo.CreateTx(ctx, db, user)
+	assert.NoError(t, err)
+
+	wrongCtx := WithScopeData(ctx, tenantScope, otherCompany.ID)
+	wrongCtx = WithUpdateScopes(wrongCtx, tenantScope)
+
+	created.Name = "Updated Name"
+	created.UpdatedAt = time.Now()
+	_, err = userRepo.UpdateTx(wrongCtx, db, created)
+	assert.Error(t, err)
+	assert.True(t, IsSQLExpectedCountViolation(err))
+
+	reloaded, err := userRepo.GetByID(ctx, created.ID.String())
+	assert.NoError(t, err)
+	assert.Equal(t, "Tenant User", reloaded.Name)
+
+	correctCtx := WithScopeData(ctx, tenantScope, tenantCompany.ID)
+	correctCtx = WithUpdateScopes(correctCtx, tenantScope)
+
+	reloaded.Name = "Updated Again"
+	reloaded.UpdatedAt = time.Now()
+	updated, err := userRepo.UpdateTx(correctCtx, db, reloaded)
+	assert.NoError(t, err)
+	assert.Equal(t, "Updated Again", updated.Name)
+}
+
 func TestRepository_GetByIdentifier_UUIDStringInCustomColumn(t *testing.T) {
 	setupTestData(t)
 
@@ -310,9 +489,111 @@ func TestRepository_Update2(t *testing.T) {
 	payload := &TestUser{}
 	userRepo.Handlers().SetID(payload, user.ID)
 	payload.Email = "alice.j@example.com"
-	updatedUser, err := userRepo.UpdateTx(ctx, db, payload, UpdateByID(user.ID.String()))
+	payload.UpdatedAt = time.Now()
+	updatedUser, err := userRepo.UpdateTx(ctx, db, payload, UpdateByID(user.ID.String()), UpdateColumns("email", "updated_at"))
 	assert.NoError(t, err)
 	assert.Equal(t, "alice.j@example.com", updatedUser.Email)
+
+	reloaded, err := userRepo.GetByID(ctx, user.ID.String())
+	assert.NoError(t, err)
+	assert.Equal(t, user.Name, reloaded.Name, "expected other fields to remain unchanged")
+}
+
+func TestRepository_Update_AllowsZeroValues(t *testing.T) {
+	setupTestData(t)
+
+	ctx := context.Background()
+	userRepo := newTestUserRepository(db)
+
+	user := &TestUser{
+		ID:        uuid.New(),
+		Name:      "NonEmpty",
+		Email:     "zero@example.com",
+		CompanyID: uuid.New(),
+	}
+	created, err := userRepo.CreateTx(ctx, db, user)
+	assert.NoError(t, err)
+
+	created.Name = ""
+	created.UpdatedAt = time.Now()
+
+	updated, err := userRepo.UpdateTx(ctx, db, created)
+	assert.NoError(t, err)
+
+	reloaded, err := userRepo.GetByID(ctx, updated.ID.String())
+	assert.NoError(t, err)
+	assert.Equal(t, "", reloaded.Name, "expected zero value to persist after update")
+}
+
+func TestRepository_Update_SkipZeroValuesCriterion(t *testing.T) {
+	setupTestData(t)
+
+	ctx := context.Background()
+	userRepo := newTestUserRepository(db)
+
+	user := &TestUser{
+		ID:        uuid.New(),
+		Name:      "KeepMe",
+		Email:     "skip-zero@example.com",
+		CompanyID: uuid.New(),
+	}
+	created, err := userRepo.CreateTx(ctx, db, user)
+	assert.NoError(t, err)
+
+	payload := &TestUser{}
+	userRepo.Handlers().SetID(payload, created.ID)
+	payload.Name = ""
+	payload.Email = "skip-zero@example.com"
+	payload.UpdatedAt = time.Now()
+
+	_, err = userRepo.UpdateTx(ctx, db, payload, UpdateByID(created.ID.String()), UpdateSkipZeroValues())
+	assert.NoError(t, err)
+
+	reloaded, err := userRepo.GetByID(ctx, created.ID.String())
+	assert.NoError(t, err)
+	assert.Equal(t, "KeepMe", reloaded.Name, "expected name to remain when UpdateSkipZeroValues is applied")
+}
+
+func TestRepository_UpdateMany_AllowsZeroValues(t *testing.T) {
+	setupTestData(t)
+
+	ctx := context.Background()
+	userRepo := newTestUserRepository(db)
+
+	users := []*TestUser{
+		{
+			ID:        uuid.New(),
+			Name:      "First",
+			Email:     "first@example.com",
+			CompanyID: uuid.New(),
+		},
+		{
+			ID:        uuid.New(),
+			Name:      "Second",
+			Email:     "second@example.com",
+			CompanyID: uuid.New(),
+		},
+	}
+
+	for _, user := range users {
+		_, err := userRepo.CreateTx(ctx, db, user)
+		assert.NoError(t, err)
+	}
+
+	users[0].Name = ""
+	users[0].UpdatedAt = time.Now()
+	users[1].Name = ""
+	users[1].UpdatedAt = time.Now()
+
+	updated, err := userRepo.UpdateManyTx(ctx, db, users)
+	assert.NoError(t, err)
+	assert.Len(t, updated, 2)
+
+	for _, original := range users {
+		reloaded, err := userRepo.GetByID(ctx, original.ID.String())
+		assert.NoError(t, err)
+		assert.Equal(t, "", reloaded.Name, "expected zero value to persist after bulk update")
+	}
 }
 
 func TestRepository_Delete(t *testing.T) {
@@ -360,6 +641,94 @@ func TestRepository_GetOrCreate(t *testing.T) {
 	secondCallCompany, err := companyRepo.GetOrCreateTx(ctx, db, company)
 	assert.NoError(t, err)
 	assert.Equal(t, firstCallCompany.ID, secondCallCompany.ID)
+}
+
+func TestRepository_GetOrCreateTx_ReturnsExistingOnDuplicateRace(t *testing.T) {
+	setupTestData(t)
+
+	ctx := context.Background()
+	userRepo := newTestUserRepository(db)
+	repoImpl := userRepo.(*repo[*TestUser])
+	repoImpl.resetScopes()
+
+	const blockerScope = "test-insert-blocker"
+	repoImpl.RegisterScope(blockerScope, ScopeDefinition{
+		Insert: func(ctx context.Context) []InsertCriteria {
+			val, ok := ScopeData(ctx, blockerScope)
+			if !ok {
+				return nil
+			}
+			blocker, ok := val.(*insertBlocker)
+			if !ok || blocker == nil {
+				return nil
+			}
+			return []InsertCriteria{
+				func(q *bun.InsertQuery) *bun.InsertQuery {
+					blocker.ready <- struct{}{}
+					<-blocker.proceed
+					return q
+				},
+			}
+		},
+	})
+	repoImpl.SetScopeDefaults(ScopeDefaults{
+		Insert: []string{blockerScope},
+	})
+
+	blocker := &insertBlocker{
+		ready:   make(chan struct{}, 1),
+		proceed: make(chan struct{}, 1),
+	}
+
+	scopeCtx := WithScopeData(ctx, blockerScope, blocker)
+
+	now := time.Now()
+
+	record := &TestUser{
+		ID:        uuid.New(),
+		Name:      "Original Name",
+		Email:     "duplicate-race@example.com",
+		CompanyID: uuid.New(),
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	var (
+		result  *TestUser
+		callErr error
+		wg      sync.WaitGroup
+	)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		res, err := userRepo.GetOrCreateTx(scopeCtx, db, record)
+		result = res
+		callErr = err
+	}()
+
+	<-blocker.ready
+
+	manual := &TestUser{
+		ID:        uuid.New(),
+		Name:      "Manual Insert",
+		Email:     record.Email,
+		CompanyID: record.CompanyID,
+		CreatedAt: now.Add(1 * time.Millisecond),
+		UpdatedAt: now.Add(1 * time.Millisecond),
+	}
+	_, err := userRepo.CreateTx(ctx, db, manual)
+	assert.NoError(t, err)
+
+	blocker.proceed <- struct{}{}
+	wg.Wait()
+
+	assert.NoError(t, callErr)
+	if assert.NotNil(t, result) {
+		assert.Equal(t, manual.Email, result.Email)
+		assert.Equal(t, manual.Name, result.Name)
+		assert.Equal(t, manual.ID, result.ID)
+	}
 }
 
 func TestRepository_DeleteWhere(t *testing.T) {
@@ -816,4 +1185,9 @@ func dropSchema(ctx context.Context, db *bun.DB) error {
 		}
 	}
 	return nil
+}
+
+type insertBlocker struct {
+	ready   chan struct{}
+	proceed chan struct{}
 }

--- a/scopes.go
+++ b/scopes.go
@@ -1,0 +1,273 @@
+package repository
+
+import (
+	"context"
+	"strings"
+)
+
+type scopeContextKey struct{}
+
+type scopeContextConfig struct {
+	useDefaults bool
+
+	all     []string
+	selects []string
+	updates []string
+	inserts []string
+	deletes []string
+
+	data map[string]any
+}
+
+// ScopeOperation identifies the repository operation type used when applying scopes.
+type ScopeOperation int
+
+const (
+	ScopeOperationSelect ScopeOperation = iota
+	ScopeOperationUpdate
+	ScopeOperationInsert
+	ScopeOperationDelete
+)
+
+// ScopeState captures the effective scope configuration for a given operation.
+type ScopeState struct {
+	Operation   ScopeOperation `json:"operation"`
+	UseDefaults bool           `json:"use_defaults"`
+	Names       []string       `json:"names"`
+	Data        map[string]any `json:"data,omitempty"`
+}
+
+// IsZero returns true when no scope names or data are configured.
+func (s ScopeState) IsZero() bool {
+	return len(s.Names) == 0 && len(s.Data) == 0 && s.UseDefaults
+}
+
+func WithScopes(ctx context.Context, names ...string) context.Context {
+	return withScopeNames(ctx, names, func(cfg *scopeContextConfig) *[]string {
+		return &cfg.all
+	})
+}
+
+func WithSelectScopes(ctx context.Context, names ...string) context.Context {
+	return withScopeNames(ctx, names, func(cfg *scopeContextConfig) *[]string {
+		return &cfg.selects
+	})
+}
+
+func WithUpdateScopes(ctx context.Context, names ...string) context.Context {
+	return withScopeNames(ctx, names, func(cfg *scopeContextConfig) *[]string {
+		return &cfg.updates
+	})
+}
+
+func WithInsertScopes(ctx context.Context, names ...string) context.Context {
+	return withScopeNames(ctx, names, func(cfg *scopeContextConfig) *[]string {
+		return &cfg.inserts
+	})
+}
+
+func WithDeleteScopes(ctx context.Context, names ...string) context.Context {
+	return withScopeNames(ctx, names, func(cfg *scopeContextConfig) *[]string {
+		return &cfg.deletes
+	})
+}
+
+func WithScopeData(ctx context.Context, name string, data any) context.Context {
+	cfg := cloneScopeContextConfig(scopeConfigFromContext(ctx))
+	if cfg.data == nil {
+		cfg.data = make(map[string]any)
+	}
+	cfg.data[strings.TrimSpace(name)] = data
+	return context.WithValue(ctx, scopeContextKey{}, cfg)
+}
+
+func ScopeData(ctx context.Context, name string) (any, bool) {
+	cfg := scopeConfigFromContext(ctx)
+	if cfg == nil || cfg.data == nil {
+		return nil, false
+	}
+	val, ok := cfg.data[strings.TrimSpace(name)]
+	return val, ok
+}
+
+func ScopeDataSnapshot(ctx context.Context) map[string]any {
+	cfg := scopeConfigFromContext(ctx)
+	if cfg == nil || cfg.data == nil {
+		return nil
+	}
+
+	snapshot := make(map[string]any, len(cfg.data))
+	for k, v := range cfg.data {
+		snapshot[k] = v
+	}
+	return snapshot
+}
+
+func WithoutDefaultScopes(ctx context.Context) context.Context {
+	cfg := cloneScopeContextConfig(scopeConfigFromContext(ctx))
+	cfg.useDefaults = false
+	return context.WithValue(ctx, scopeContextKey{}, cfg)
+}
+
+func ResolveScopeState(ctx context.Context, defaults ScopeDefaults, op ScopeOperation) ScopeState {
+	contextNames, useDefaults := scopeNamesForOperation(ctx, op)
+
+	var names []string
+	if useDefaults {
+		names = append(names, defaults.All...)
+		switch op {
+		case ScopeOperationSelect:
+			names = append(names, defaults.Select...)
+		case ScopeOperationUpdate:
+			names = append(names, defaults.Update...)
+		case ScopeOperationInsert:
+			names = append(names, defaults.Insert...)
+		case ScopeOperationDelete:
+			names = append(names, defaults.Delete...)
+		}
+	}
+
+	if len(contextNames) > 0 {
+		names = append(names, contextNames...)
+	}
+
+	return ScopeState{
+		Operation:   op,
+		UseDefaults: useDefaults,
+		Names:       uniqueStrings(names),
+		Data:        ScopeDataSnapshot(ctx),
+	}
+}
+
+// CloneScopeDefaults creates a deep copy of the provided scope defaults.
+func CloneScopeDefaults(defaults ScopeDefaults) ScopeDefaults {
+	return ScopeDefaults{
+		All:    copyStrings(defaults.All),
+		Select: copyStrings(defaults.Select),
+		Update: copyStrings(defaults.Update),
+		Insert: copyStrings(defaults.Insert),
+		Delete: copyStrings(defaults.Delete),
+	}
+}
+
+func scopeConfigFromContext(ctx context.Context) *scopeContextConfig {
+	if ctx == nil {
+		return nil
+	}
+	if cfg, ok := ctx.Value(scopeContextKey{}).(*scopeContextConfig); ok {
+		return cfg
+	}
+	return nil
+}
+
+func scopeNamesForOperation(ctx context.Context, op ScopeOperation) ([]string, bool) {
+	cfg := scopeConfigFromContext(ctx)
+	if cfg == nil {
+		return nil, true
+	}
+
+	var selection []string
+	switch op {
+	case ScopeOperationSelect:
+		selection = cfg.selects
+	case ScopeOperationUpdate:
+		selection = cfg.updates
+	case ScopeOperationInsert:
+		selection = cfg.inserts
+	case ScopeOperationDelete:
+		selection = cfg.deletes
+	default:
+		selection = nil
+	}
+
+	combined := append([]string{}, cfg.all...)
+	if len(selection) > 0 {
+		combined = append(combined, selection...)
+	}
+
+	return combined, cfg.useDefaults
+}
+
+func cloneScopeContextConfig(cfg *scopeContextConfig) *scopeContextConfig {
+	if cfg == nil {
+		return &scopeContextConfig{
+			useDefaults: true,
+		}
+	}
+
+	cloned := &scopeContextConfig{
+		useDefaults: cfg.useDefaults,
+		all:         copyStrings(cfg.all),
+		selects:     copyStrings(cfg.selects),
+		updates:     copyStrings(cfg.updates),
+		inserts:     copyStrings(cfg.inserts),
+		deletes:     copyStrings(cfg.deletes),
+	}
+
+	if cfg.data != nil {
+		cloned.data = make(map[string]any, len(cfg.data))
+		for k, v := range cfg.data {
+			cloned.data[k] = v
+		}
+	}
+
+	return cloned
+}
+
+func withScopeNames(ctx context.Context, names []string, target func(*scopeContextConfig) *[]string) context.Context {
+	if len(names) == 0 {
+		return ctx
+	}
+
+	cfg := cloneScopeContextConfig(scopeConfigFromContext(ctx))
+	dest := target(cfg)
+
+	for _, name := range names {
+		if trimmed := strings.TrimSpace(name); trimmed != "" && !containsString(*dest, trimmed) {
+			*dest = append(*dest, trimmed)
+		}
+	}
+
+	return context.WithValue(ctx, scopeContextKey{}, cfg)
+}
+
+func containsString(list []string, value string) bool {
+	for _, item := range list {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}
+
+func copyStrings(src []string) []string {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]string, len(src))
+	copy(dst, src)
+	return dst
+}
+
+func uniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		result = append(result, v)
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}


### PR DESCRIPTION
This PR adds a new feature: scopes. 


Scopes let you register reusable filters that are applied automatically to repository operations.

```go
const tenantScope = "tenant"

userRepo.RegisterScope(tenantScope, repository.ScopeDefinition{
    Select: func(ctx context.Context) []repository.SelectCriteria {
        value, ok := repository.ScopeData(ctx, tenantScope)
        if !ok {
            return nil
        }
        tenantID, ok := value.(uuid.UUID)
        if !ok || tenantID == uuid.Nil {
            return nil
        }
        return []repository.SelectCriteria{
            repository.SelectBy("company_id", "=", tenantID.String()),
        }
    },
})

if err := userRepo.SetScopeDefaults(repository.ScopeDefaults{
    Select: []string{tenantScope},
}); err != nil {
    panic(err)
}
``` 